### PR TITLE
Update to default to main branch.

### DIFF
--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -6,9 +6,10 @@ python3 `which mkrepo` {{cookiecutter.repo_name}} --YES
 
 # is this the same as cloning?
 git init .
+git checkout -b main
 git remote add adafruit {{cookiecutter.github_repo_url}}
 git fetch adafruit
-git merge adafruit/master
+git merge adafruit/main
 
 # add stuff
 wget {{cookiecutter.image_url}} -O assets/{{cookiecutter.pid}}.jpg


### PR DESCRIPTION
New repos created now use `main` as the default branch, versus the previous default `master`. `git init` still defaults to `master` if no initial branch is specified. You can specify an initial branch with `--initial-branch=main`, however this feature is only available in the latest git. Therefore to avoid failures for those who have not updated git, I added a `checkout -b` which is available in previous versions.