### PR TITLE
Add fast-fail, use gh CLI

### DIFF
--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -1,35 +1,45 @@
 #!/bin/bash
+
+# Make assets folder
 mkdir assets/
-# make idempotent
+
+# Print the current working directory
 pwd
-python3 `which mkrepo` {{cookiecutter.repo_name}} --YES
+
+# Create the GitHub repository
+gh repo create adafruit/{{ cookiecutter.repo_name }} --public
+if [ $? != 0 ]; then
+    echo "Failed to create repo on GitHub."
+    echo "Please check the following:"
+    echo " * An Adafruit repository named {{ cookiecutter.repo_name }} does not already exist"
+    echo " * You are authenticated for the gh CLI"
+    echo " * You have permission to create repositories for Adafruit"
+    exit 1
+fi
 
 # Remove factory-reset if not needed
 {% if cookiecutter.dev_board in ['n', 'no'] %}rm -rf factory-reset{% endif %}
 
-# Setup repo
+# Setup repo via git
 git init .
 git checkout -b main
 git remote add adafruit {{cookiecutter.github_repo_url}}
 git fetch adafruit
-git merge adafruit/main
 
 # Add content
 wget {{cookiecutter.image_url}} -O assets/{{cookiecutter.pid}}.jpg
 git rm readme.txt
 
-# copy over files
+# Copy over files
 echo 'cp {{cookiecutter.board_file_directory}}/{{cookiecutter.board_file_name}}.brd ./Adafruit_{{cookiecutter.product_name}}.brd'
 echo 'cp {{cookiecutter.board_file_directory}}/{{cookiecutter.board_file_name}}.sch ./Adafruit_{{cookiecutter.product_name}}.sch'
 cp {{cookiecutter.board_file_directory}}/*{{cookiecutter.board_file_name}}*.brd ./Adafruit_{{cookiecutter.product_name}}.brd
 cp {{cookiecutter.board_file_directory}}/*{{cookiecutter.board_file_name}}*.sch ./Adafruit_{{cookiecutter.product_name}}.sch
-
-echo "Copied over"
-echo and
+echo "Board and schematic files copied over."
 echo "Make sure they're the correct version!"
 
+# Stage additions
 git add .
 echo "DONE! Review, make changes, git add, push!"
-
 
 exit 0

--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -7,7 +7,7 @@ mkdir assets/
 pwd
 
 # Create the GitHub repository
-gh repo create adafruit/{{ cookiecutter.repo_name }} --public
+gh repo create adafruit/{{ cookiecutter.repo_name }} -d "PCB files for {{ cookiecutter.full-name }}." --public
 if [ $? != 0 ]; then
     echo "Failed to create repo on GitHub."
     echo "Please check the following:"

--- a/hooks/pre_gen_project.sh
+++ b/hooks/pre_gen_project.sh
@@ -11,8 +11,8 @@ check_for_program () {
 # Check for `git`
 check_for_program git
 
-# Check for `python3`
-check_for_program python3
+# Check for `gh` CLI
+check_for_program gh
 
 # Check for `wget`
 check_for_program wget

--- a/hooks/pre_gen_project.sh
+++ b/hooks/pre_gen_project.sh
@@ -1,4 +1,22 @@
 #!/bin/bash
+
+check_for_program () {
+    commandpath="$(command -v $1)"
+    if [ -z $commandpath ]; then
+        echo "$1 not installed!  Exiting PCB cookiecutter."
+        exit 1
+    fi
+}
+
+# Check for `git`
+check_for_program git
+
+# Check for `python3`
+check_for_program python3
+
+# Check for `wget`
+check_for_program wget
+
 echo "pre-generate"
 echo "{{cookiecutter.pid}} is PID"
 exit 


### PR DESCRIPTION
Adds more to the pre-gen hook to check for commands and fast-fail if they aren't available/installed.

Also adds the ability to create the Adafruit repository using the `gh` CLI.

Fixes #2
Fixes #3